### PR TITLE
fix: only run `useLayout` in the client

### DIFF
--- a/packages/core/src/composables/use-layout.ts
+++ b/packages/core/src/composables/use-layout.ts
@@ -34,9 +34,6 @@ const STYLE_INCLUDES = [
 ]
 
 export function useLayout(target: MaybeRef<HTMLElement | SVGElement | undefined>, options: MaybeRef<UseHeroProps>, ctx?: HeroContext) {
-  if (import.meta.server)
-    return
-
   let motionInstance: any
 
   const bounding: Record<string, number> = { x: 0, y: 0, width: 0, height: 0 }

--- a/packages/core/src/composables/use-layout.ts
+++ b/packages/core/src/composables/use-layout.ts
@@ -34,6 +34,9 @@ const STYLE_INCLUDES = [
 ]
 
 export function useLayout(target: MaybeRef<HTMLElement | SVGElement | undefined>, options: MaybeRef<UseHeroProps>, ctx?: HeroContext) {
+  if (import.meta.server)
+    return
+
   let motionInstance: any
 
   const bounding: Record<string, number> = { x: 0, y: 0, width: 0, height: 0 }

--- a/packages/core/src/composables/use-style.ts
+++ b/packages/core/src/composables/use-style.ts
@@ -40,10 +40,13 @@ function useTransform(target: PermissiveTarget) {
 }
 
 export function useStyle(target: PermissiveTarget, options: UseStyleOptions = {}) {
-  let observer: MutationObserver
-
-  const domRef = toRef(target)
   const transform = ref<Partial<Transform>>({})
+
+  if (import.meta.server)
+    return { transform }
+
+  let observer: MutationObserver
+  const domRef = toRef(target)
 
   if (domRef.value)
     transform.value = useTransform(domRef).value


### PR DESCRIPTION
`useStyle` uses `MutationObserver` which causes an error when using SSR.

The current workaround is using `<ClientOnly />` component.

Not sure if this is a good solution as I am not familiar with the codebase, but feel free to close this PR if using `<ClientOnly />` is what we want.

Thanks for this great library 🫰